### PR TITLE
Exclude Stan-generated C++ from coverage via .covignore

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -8,3 +8,4 @@ src/stanExports*
 src/*.dll
 ^\.lintr$
 ^\.github$
+^\.covignore$

--- a/.covignore
+++ b/.covignore
@@ -1,0 +1,12 @@
+# covr exclusion patterns. Matches gitignore-style globs against paths
+# relative to the package root. See:
+# https://cran.r-project.org/web/packages/covr/readme/README.html
+
+# Stan-generated C++ — emitted by rstantools from inst/stan/*.stan during
+# package build. There's no good way to unit-test it from R, and treating
+# it as coverable inflates the file count without measuring anything we
+# can act on. The Stan models themselves are exercised by integration
+# tests via hestia(), but coverage is recorded against the .stan source,
+# which covr doesn't instrument anyway.
+src/stanExports_*.cc
+src/stanExports_*.h


### PR DESCRIPTION
## Summary

Adds a `.covignore` at the package root so `covr::package_coverage()` skips the Stan-generated C++ in `src/stanExports_*.{cc,h}`. These files are emitted by rstantools from `inst/stan/*.stan` at package build time, can't be meaningfully unit-tested from R, and inflate the coverage file count without measuring anything actionable. The Stan models are still exercised by integration tests via `hestia()`, but covr doesn't instrument the `.stan` sources anyway.

Also adds `^\.covignore$` to `.Rbuildignore` so the file is not bundled into the built source tarball (avoiding a non-standard top-level file `NOTE` from `R CMD check`).

Closes #28. Refs #22. Direct port of ACCIDDA/imuGAP#56.

## Verification

`covr::package_coverage()` reads `.covignore` automatically — see covr's README: https://cran.r-project.org/web/packages/covr/readme/README.html.

This PR is queued behind #23 — keeping it as draft until that lands.
