### PR TITLE
Add GitHub issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,41 @@
+name: Bug Report
+description: Report something that isn't working correctly
+labels: ["bug"]
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: What happened, and what did you expect to happen?
+    validations:
+      required: true
+
+  - type: textarea
+    id: reprex
+    attributes:
+      label: Minimal reproducible example
+      description: Paste a short R script that reproduces the problem. Wrap in a code fence.
+      render: r
+    validations:
+      required: false
+
+  - type: textarea
+    id: session_info
+    attributes:
+      label: Session info
+      description: Paste the output of `sessionInfo()`.
+      render: text
+    validations:
+      required: true
+
+  - type: dropdown
+    id: os
+    attributes:
+      label: Operating system
+      options:
+        - macOS
+        - Ubuntu / Linux
+        - Windows
+        - Other
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: true

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,27 @@
+name: Feature Request
+description: Suggest a new feature or improvement
+labels: ["enhancement"]
+body:
+  - type: textarea
+    id: use_case
+    attributes:
+      label: Use case
+      description: What problem would this feature solve? How does it fit into the hestia workflow?
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposed_solution
+    attributes:
+      label: Proposed solution
+      description: How do you think this should work?
+    validations:
+      required: false
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Any other approaches you have thought about.
+    validations:
+      required: false


### PR DESCRIPTION
## Summary

- Adds form-style GitHub issue templates for bug reports and feature requests under `.github/ISSUE_TEMPLATE/`.
- Includes `config.yml` with `blank_issues_enabled: true` so contributors can still open a blank issue when neither form fits.
- Direct port of imuGAP PR [#37](https://github.com/ACCIDDA/imuGAP/pull/37), with wording adapted to reference hestia.

## Files

- `.github/ISSUE_TEMPLATE/bug_report.yml` — description, repro, `sessionInfo()`, OS dropdown (labels: `bug`).
- `.github/ISSUE_TEMPLATE/feature_request.yml` — use case, proposed solution, alternatives (labels: `enhancement`).
- `.github/ISSUE_TEMPLATE/config.yml` — enables blank issues.

## Notes

- Labels `bug` and `enhancement` already exist on this repo.
- Draft because PR #23 is in flight; this can queue behind it.

Closes #30
Refs #22

## Test plan

- [ ] Verify GitHub renders the two forms on the "New issue" page.
- [ ] Confirm submitted issues get the expected `bug` / `enhancement` label automatically.
- [ ] Confirm the "Open a blank issue" link still appears under the form chooser.
