### PR TITLE
Align lint config with imuGAP and fix R source lints

### DIFF
--- a/.lintr
+++ b/.lintr
@@ -1,3 +1,13 @@
-linters: linters_with_defaults() # see vignette("lintr")
+linters: linters_with_defaults(
+    line_length_linter = line_length_linter(100L),
+    object_usage_linter = NULL,
+    object_name_linter = object_name_linter(
+      styles = c("snake_case", "symbols"),
+      regexes = "^hestia$"
+    ),
+    return_linter(
+      return_style = "implicit"
+    )
+  )
 encoding: "UTF-8"
-exclusions: list("R/hestia-package.R", "R/stanmodels.R")
+exclusions: list("R/hestia-package.R", "R/stanmodels.R", "inst/auxillary", "vignettes")

--- a/R/hestia_functions.R
+++ b/R/hestia_functions.R
@@ -36,7 +36,7 @@ split_check <- function(to, split) {
     if (sum(is.na(split)) >= 1) {
       # otherwise NA not OK
       stop("Improper specification for split - cannot contain NA")
-    } else if (!(is.character(split) | is.numeric(split))) {
+    } else if (!(is.character(split) || is.numeric(split))) {
       # Must be character or numeric
       stop("Must provide character or numeric values for split")
     } else if (is.numeric(split)) {
@@ -91,7 +91,7 @@ split_check <- function(to, split) {
 #'
 #' @keywords internal
 to_from_check <- function(to, from) {
-  if (length(from) == 0 | length(to) == 0) {
+  if (length(from) == 0 || length(to) == 0) {
     stop("'to' and 'from' arguments cannot be empty")
   }
 
@@ -99,7 +99,7 @@ to_from_check <- function(to, from) {
     stop("'from' must be of length one")
   }
 
-  if (!is.character(from) | !is.character(to)) {
+  if (!is.character(from) || !is.character(to)) {
     stop("'to' and 'from' arguments must be characters")
   }
 
@@ -346,7 +346,7 @@ make_infection_model <- function(..., mult_inf_probs = FALSE) {
   graph <- matrix(0, nrow = length(states), ncol = length(states))
   rownames(graph) <- states
   colnames(graph) <- states
-  for (i in 1:nrow(out)) {
+  for (i in seq_len(nrow(out))) {
     graph[out$from[i], out$to[i]] <- 1
     graph[out$to[i], out$from[i]] <- 1
   }
@@ -1003,5 +1003,5 @@ rename_chains <- function(inf_model, model_output) {
   draws <- posterior::subset_draws(draws_full, variable = var_names_sub)
   posterior::variables(draws) <- var_names_new
 
-  return(draws)
+  draws
 }


### PR DESCRIPTION
Fixes the failing `lint` CI check (which #23/#31/#32 all inherit).

The lint job was failing because hestia used the strict default lintr config while imuGAP relaxes the things that were tripping it. This matches imuGAP's `.lintr`:
- 100-char line limit
- `object_usage_linter` off
- implicit returns
- snake_case object names

It also excludes the non-source dirs from linting (`inst/auxillary` scripts + `vignettes`), the same way imuGAP excludes `inst/analysis` / `inst/scripts`. The vignettes had finicky `indentation_linter` violations on demo code that aren't worth reformatting teaching examples over.

Plus the real lints in `R/hestia_functions.R` that survive the config change:
- `|` -> `||` in three scalar conditionals
- `1:nrow(...)` -> `seq_len(nrow(...))` (correct in the empty-data edge case)
- dropped an unnecessary explicit `return()`

Refs #34. Note: the `macos-latest (devel)` failure is a separate issue, still being diagnosed (its log isn't available until the R CMD check run finishes).