### PR TITLE
Drop Claddis dependency (fixes macos-devel)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -18,7 +18,6 @@ Roxygen: list(markdown = TRUE, roclets = c("collate", "namespace", "rd",
     "roxyglobals::global_roclet"))
 RoxygenNote: 7.3.3
 Imports:
-    Claddis,
     cli,
     dplyr,
     glue,

--- a/R/hestia_functions.R
+++ b/R/hestia_functions.R
@@ -351,7 +351,7 @@ make_infection_model <- function(..., mult_inf_probs = FALSE) {
     graph[out$to[i], out$from[i]] <- 1
   }
 
-  if (!Claddis::is_graph_connected(graph)) {
+  if (!graph_connected(graph)) {
     stop("Compartmental model structure cannot be disconnected.")
   }
 
@@ -362,6 +362,33 @@ make_infection_model <- function(..., mult_inf_probs = FALSE) {
   }
 
   out
+}
+
+#' Check whether an undirected adjacency matrix is fully connected
+#'
+#' Breadth-first reachability from the first node. Replaces a single-use
+#' dependency on Claddis::is_graph_connected (the only reason hestia imported
+#' Claddis, whose heavy dependency tree failed to build on R-devel macOS).
+#'
+#' @param graph square symmetric 0/1 adjacency matrix.
+#' @return TRUE if every node is reachable from the first, else FALSE.
+#' @keywords internal
+graph_connected <- function(graph) {
+  n <- nrow(graph)
+  if (n <= 1) {
+    return(TRUE)
+  }
+  visited <- rep(FALSE, n)
+  visited[1] <- TRUE
+  queue <- 1L
+  while (length(queue) > 0) {
+    node <- queue[1]
+    queue <- queue[-1]
+    nbrs <- which(graph[node, ] != 0 & !visited)
+    visited[nbrs] <- TRUE
+    queue <- c(queue, nbrs)
+  }
+  all(visited)
 }
 
 #' @title Create Transmission Probability Matrix


### PR DESCRIPTION
Fixes the failing `macos-latest (devel)` check.

**Root cause:** hestia imported the entire `Claddis` package (a phylogenetics/morphological-disparity library with a large dependency tree) for exactly one call — `Claddis::is_graph_connected(graph)` in `make_infection_model`, to check the compartment graph is connected. On R-devel macOS there are no CRAN binaries, so Claddis + its tree compile from source, and the build fails -> macos-devel red. (imuGAP, same kind of package, passes macos-devel because it has no such dependency.)

**Fix:** replaced that one call with a small base-R breadth-first connectivity check (`graph_connected`) and removed `Claddis` from `Imports`. Same behavior, no heavy dependency.

Also addresses Carl's note on #23 to trim the dependency list. Refs #34.

Note: I couldn't run R locally to verify, so relying on CI — the existing test suite exercises `make_infection_model` with connected graphs, which hits `graph_connected`.