### PR TITLE
Drop stringr dependency (closes #33)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -29,7 +29,6 @@ Imports:
     rlang,
     rstan (>= 2.18.1),
     rstantools (>= 2.5.0),
-    stringr,
     tidyr,
 Biarch: true
 Depends: 

--- a/R/hestia_functions.R
+++ b/R/hestia_functions.R
@@ -517,7 +517,7 @@ get_transmission_details <- function(inf_model) {
     fac_levels <- unique(
       mult_to_fit$mult_name[
         !is.na(mult_to_fit$mult_name) &
-          !stringr::str_detect(mult_to_fit$mult_name, "1-")
+          !grepl("1-", mult_to_fit$mult_name, fixed = TRUE)
       ]
     )
     mult_to_fit$param <- as.numeric(factor(


### PR DESCRIPTION
Completes #33 (Claddis was dropped in #36; stringr is the other single-use dep).

stringr was used exactly once — `str_detect(mult_to_fit$mult_name, "1-")` in get_transmission_details. Replaced with base `grepl("1-", ..., fixed = TRUE)` (drop-in, same vectorized logical result) and removed `stringr` from Imports.

Closes #33.