### PR TITLE
Add README, CONTRIBUTING, and CITATION.cff

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,30 @@
+cff-version: 1.2.0
+message: "If you use this software, please cite it as below."
+title: "hestia - Bayesian Compartmental Infection Models from Individual Outcomes"
+abstract: >-
+  Fits Bayesian compartmental infection models (such as
+  susceptible-infected-recovered and multi-compartment hidden Markov
+  variants) from individual-level outcome data. Models are composed from
+  infection-process and observation-process components and fit using Stan
+  via rstan.
+type: software
+version: "0.0.0.9000"
+license: MIT
+repository-code: "https://github.com/ACCIDDA/hestia"
+url: "https://accidda.github.io/hestia/"
+authors:
+  - family-names: Smith
+    given-names: Claire Perrin
+    email: clairesmith6995@gmail.com
+    orcid: "https://orcid.org/0000-0003-1069-9460"
+  - family-names: Goodall
+    given-names: Jack
+    email: jackwgoodall@hotmail.com
+keywords:
+  - bayesian
+  - compartmental-model
+  - hidden-markov-model
+  - infectious-disease
+  - epidemiology
+  - stan
+  - rstan

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,87 @@
+# Contributing to hestia
+
+Thank you for your interest in contributing to hestia! This document
+explains how to report issues, propose changes, and what to expect from
+the CI pipeline when you open a pull request.
+
+## Code of Conduct
+
+All contributors are expected to be respectful and professional in all
+interactions — issues, pull requests, code reviews, and discussions.
+Constructive feedback is welcome; personal attacks and dismissive
+language are not.
+
+## Reporting Bugs
+
+Use the [bug report template](https://github.com/ACCIDDA/hestia/issues/new?template=bug_report.yml)
+when opening a new issue. It asks for a description, a minimal reprex,
+your `sessionInfo()` output, and your operating system.
+
+## Suggesting Features
+
+Use the [feature request template](https://github.com/ACCIDDA/hestia/issues/new?template=feature_request.yml).
+Describe the use case and, if possible, how the feature fits into the
+existing model workflow (`make_infection_model()` -> `run_model()` ->
+post-processing). You can also open a blank issue if neither template fits.
+
+## Submitting Changes
+
+1. **Fork & branch.** Create a feature branch off `main` (e.g.
+   `fix/split-check` or `feature/missing-outcomes`).
+2. **Make your changes.** Follow the style conventions below.
+3. **Test locally.** Run `R CMD check` and the test suite before
+   pushing (see the commands below).
+4. **Open a pull request** against `main` with a clear description of
+   what changed and why.
+
+### Local Development Commands
+
+```sh
+# Full rebuild + install (required after editing any .stan file)
+R CMD INSTALL --preclean .
+
+# Regenerate documentation from roxygen comments
+Rscript -e 'devtools::document()'
+
+# Run the test suite
+Rscript -e 'devtools::test()'
+
+# Lint the package (config in .lintr)
+Rscript -e 'lintr::lint_package()'
+
+# Build and check
+R CMD build . && R CMD check hestia_*.tar.gz
+```
+
+### Style
+
+- R code is linted with `lintr` (configuration in `.lintr`).
+  `R/stanmodels.R`, `R/hestia-package.R`, `inst/auxillary/`, and
+  `vignettes/` are excluded from linting because they are generated or
+  standalone.
+- Do not hand-edit generated files: `R/stanmodels.R`,
+  `src/stanExports_*.{cc,h}`, `configure`, and `configure.win` are all
+  produced by `rstantools::rstan_config()`. The `man/*.Rd` help pages are
+  regenerated from roxygen comments in CI, so edit the roxygen, not the
+  `.Rd`.
+- Stan model variants are composed via `#include` toggling in the
+  top-level `.stan` files — prefer toggling includes over duplicating
+  whole model files.
+
+## What Happens When You Open a PR
+
+Every pull request triggers these GitHub Actions workflows:
+
+| Workflow | What it does |
+|----------|-------------|
+| **R-CMD-check** | Runs `R CMD check --as-cran` on Ubuntu, macOS, and Windows across R release, oldrel, and devel (9 jobs total). R-devel jobs are allowed to fail without blocking the PR. Stan compilation artifacts are cached per OS and R version. |
+| **lint** | Runs `lintr::lint_package()`. |
+| **test-coverage** | Runs the test suite under `covr` and uploads coverage to Codecov. |
+| **pkgdown** | Builds the documentation site. On PRs this is a build-only check (no deployment); the site is deployed to GitHub Pages on pushes to `main`, published releases, and manual workflow dispatches. |
+
+These workflows should pass before a PR is merged.
+
+## Questions?
+
+If something is unclear, open an issue or comment on an existing one —
+we are happy to help.

--- a/README.md
+++ b/README.md
@@ -1,1 +1,45 @@
-Nice words here
+# hestia
+
+[![R-CMD-check](https://github.com/ACCIDDA/hestia/actions/workflows/R-CMD-check.yaml/badge.svg)](https://github.com/ACCIDDA/hestia/actions/workflows/R-CMD-check.yaml)
+[![lint](https://github.com/ACCIDDA/hestia/actions/workflows/lint.yaml/badge.svg)](https://github.com/ACCIDDA/hestia/actions/workflows/lint.yaml)
+[![pkgdown](https://github.com/ACCIDDA/hestia/actions/workflows/pkgdown.yaml/badge.svg)](https://github.com/ACCIDDA/hestia/actions/workflows/pkgdown.yaml)
+[![codecov](https://codecov.io/gh/ACCIDDA/hestia/branch/main/graph/badge.svg)](https://app.codecov.io/gh/ACCIDDA/hestia)
+
+`{hestia}` fits Bayesian compartmental infection models — such as
+susceptible-infected-recovered (SIR) and multi-compartment hidden Markov
+variants — from individual-level outcome data. Models are composed from
+infection-process and observation-process components and fit using Stan via
+`{rstan}`.
+
+## Installation
+
+```r
+remotes::install_github("ACCIDDA/hestia")
+```
+
+Requires R >= 4.1.0 and a C++ toolchain (for Stan model compilation).
+
+## Usage
+
+Compose an infection-process model from `transmit()` (transmission between
+compartments) and `progress()` (within-host progression) steps:
+
+```r
+library(hestia)
+
+# A basic SIR model: S -> I transmission, I -> R recovery (rate fit from data)
+inf_process <- make_infection_model(
+  transmit(from = "S", to = "I"),
+  progress(from = "I", to = "R", gamma = NA)
+)
+```
+
+Pair the infection process with an observation model
+(`make_observation_model()`) and fit it with `run_model()`. See the
+[vignettes](https://accidda.github.io/hestia/articles/) for full worked
+examples, including a multi-compartment (symptomatic/asymptomatic) model.
+
+## Part of ACCIDDA
+
+`{hestia}` is developed by the [Atlantic Coast Center for Infectious Disease
+Dynamics and Analytics (ACCIDDA)](https://accidda.org/).


### PR DESCRIPTION
Repo polish, adapted from imuGAP's versions.

- **README.md** — real package overview (was a placeholder), install instructions, a basic SIR usage snippet, and CI + codecov badges. Closes #13; the codecov badge completes the remaining piece of #27.
- **CONTRIBUTING.md** — bug/feature issue templates, local dev commands, style notes (incl. that `man/*.Rd` is CI-generated, don't hand-edit), and the CI workflow table. Closes #12.
- **CITATION.cff** — standard citation metadata with the hestia authors. Refs #21 (the actual Zenodo DOI and its README badge come at first release).

Closes #13, closes #12, closes #27.