### PR TITLE
Make repo Zenodo-ready: metadata, CITATION, DOI badge

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -9,3 +9,5 @@ src/*.dll
 ^\.lintr$
 ^\.github$
 ^\.covignore$
+^\.zenodo\.json$
+^CITATION\.cff$

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,0 +1,37 @@
+{
+  "title": "hestia - Bayesian Compartmental Infection Models from Individual Outcomes",
+  "description": "Fit Bayesian compartmental infection models (such as susceptible-infected-recovered and multi-compartment hidden Markov variants) from individual-level outcome data. Models are composed from infection-process and observation-process components and fit using Stan via rstan.",
+  "upload_type": "software",
+  "license": "MIT",
+  "access_right": "open",
+  "creators": [
+    {
+      "name": "Smith, Claire Perrin",
+      "orcid": "0000-0003-1069-9460"
+    },
+    {
+      "name": "Goodall, Jack"
+    }
+  ],
+  "keywords": [
+    "bayesian",
+    "compartmental-model",
+    "hidden-markov-model",
+    "infectious-disease",
+    "epidemiology",
+    "stan",
+    "rstan"
+  ],
+  "related_identifiers": [
+    {
+      "identifier": "https://github.com/ACCIDDA/hestia",
+      "relation": "isSupplementTo",
+      "scheme": "url"
+    },
+    {
+      "identifier": "https://accidda.github.io/hestia/",
+      "relation": "isDocumentedBy",
+      "scheme": "url"
+    }
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -4,6 +4,17 @@
 [![lint](https://github.com/ACCIDDA/hestia/actions/workflows/lint.yaml/badge.svg)](https://github.com/ACCIDDA/hestia/actions/workflows/lint.yaml)
 [![pkgdown](https://github.com/ACCIDDA/hestia/actions/workflows/pkgdown.yaml/badge.svg)](https://github.com/ACCIDDA/hestia/actions/workflows/pkgdown.yaml)
 [![codecov](https://codecov.io/gh/ACCIDDA/hestia/branch/main/graph/badge.svg)](https://app.codecov.io/gh/ACCIDDA/hestia)
+[![DOI](https://zenodo.org/badge/DOI/PENDING.svg)](https://doi.org/PENDING)
+
+<!--
+Zenodo DOI badge placeholder. Zenodo tracking is already enabled for this
+repo, but the DOI is only minted when the first GitHub Release is published.
+After that first release, replace the two PENDING values above with the
+concept DOI (the version-independent DOI that always resolves to the latest
+release). Zenodo also displays the exact badge Markdown on the deposition
+page once a release exists.
+-->
+
 
 `{hestia}` fits Bayesian compartmental infection models — such as
 susceptible-infected-recovered (SIR) and multi-compartment hidden Markov

--- a/inst/CITATION
+++ b/inst/CITATION
@@ -1,0 +1,19 @@
+citHeader("To cite hestia in publications, please use:")
+
+bibentry(
+  bibtype  = "Manual",
+  title    = "{hestia}: Bayesian Compartmental Infection Models from Individual Outcomes",
+  author   = c(
+    person("Claire Perrin", "Smith"),
+    person("Jack", "Goodall")
+  ),
+  year     = "2026",
+  note     = "R package version 0.0.0.9000",
+  url      = "https://github.com/ACCIDDA/hestia",
+  textVersion = paste(
+    "Smith, Claire Perrin and Goodall, Jack (2026).",
+    "hestia: Bayesian Compartmental Infection Models from Individual Outcomes.",
+    "R package version 0.0.0.9000.",
+    "https://github.com/ACCIDDA/hestia"
+  )
+)


### PR DESCRIPTION
Scaffolds everything needed to make hestia citable and Zenodo-ready.

## Changes

- **.zenodo.json**: repo-tracked Zenodo metadata (title, description, creators from DESCRIPTION Authors@R with ORCID, MIT license, keywords, related links).
- **inst/CITATION**: the source for R's `citation("hestia")`, consistent with DESCRIPTION (title, authors, version, URL).
- **CITATION.cff**: already present and accurate; verified it matches DESCRIPTION, left unchanged.
- **README.md**: added a Zenodo DOI badge using a `PENDING` placeholder, with an inline note explaining how to finalize it.
- **.Rbuildignore**: excludes `.zenodo.json` and `CITATION.cff` from the R build tarball.

## Manual Zenodo steps that remain (cannot be automated here)

Minting the actual DOI is an external manual step; this PR only scaffolds the metadata and badge.

1. Zenodo GitHub tracking is already enabled for this repo (per @pearsonca on #21), so no integration toggle is needed.
2. Publish a GitHub Release (e.g. tag the first version). Zenodo mints the DOI automatically on release.
3. On the Zenodo deposition page, copy the concept DOI (the version-independent DOI that resolves to the latest release) and the badge Markdown.
4. Replace the two `PENDING` values in the README DOI badge with the concept DOI, and remove the placeholder comment.

Closes #21