### PR TITLE
Add roxygen docs for simulation functions

### DIFF
--- a/inst/auxillary/simulation.R
+++ b/inst/auxillary/simulation.R
@@ -1,3 +1,25 @@
+#' @title Build one time step of household observations
+#'
+#' @description Helper used by the simulation functions to assemble the rows for
+#'   a single household on a single time step. On the first time step states are
+#'   drawn from the starting state probabilities; on later steps the already
+#'   computed states are carried in directly.
+#'
+#' @param d Integer time step. When `d == 1` states are sampled from
+#'   `state_info`, otherwise `state_info` is treated as the states themselves.
+#' @param i Integer index of the household being built.
+#' @param hh_size Integer vector of household sizes, indexed by household.
+#' @param part_ids List of participant ID vectors, one element per household.
+#' @param enroll_per_hh Integer vector giving the number of enrolled
+#'   participants in each household.
+#' @param state_info On the first time step, a vector of starting state
+#'   probabilities. On later time steps, the vector of member states for the
+#'   household.
+#'
+#' @return A data frame with one row per household member and the columns `t`,
+#'   `part_id`, `enroll`, `state`, `hh_size`, and `hh_id`.
+#'
+#' @keywords internal
 make_new_obs <- function(d, i, hh_size, part_ids, enroll_per_hh, state_info) {
   if (d == 1) {
     data.frame(
@@ -31,9 +53,58 @@ make_new_obs <- function(d, i, hh_size, part_ids, enroll_per_hh, state_info) {
   }
 }
 
-#' @title Simulate SIR data
-#' @description Simulate household data for a pathogen following an SIR model
+#' @title Simulate SIR household data
 #'
+#' @description Simulate longitudinal household outcome data for a pathogen that
+#'   follows a susceptible-infected-recovered (SIR) process. Members move
+#'   through three states (1 = susceptible, 2 = infected, 3 = recovered) and
+#'   each true state generates one or more binary observations through an
+#'   observation process.
+#'
+#' @details Each household is simulated independently for `tmax` time steps.
+#'   Susceptible members can be infected from outside the household (extra
+#'   household) or by infected household members (intra household); the
+#'   probabilities can be shifted by covariates through `covs_eh` and `covs_ih`.
+#'   Infected members recover at rate `gamma`. For each true state, every
+#'   observation type in `obs_prob` produces a positive result with the listed
+#'   probability.
+#'
+#' @param eh_prob Baseline per step probability that a susceptible member is
+#'   infected from outside the household.
+#' @param ih_prob Baseline per step probability that a susceptible member is
+#'   infected by a single infected household member.
+#' @param n_hh Number of households to simulate.
+#' @param hh_size Vector of possible household sizes; each household size is
+#'   drawn from this vector with replacement.
+#' @param tmax Number of time steps to simulate per household.
+#' @param gamma Per step probability that an infected member recovers.
+#' @param covs_eh Numeric vector of coefficients for the extra household
+#'   covariates, on the logit scale.
+#' @param covs_ih Numeric vector of coefficients for the intra household
+#'   covariates, on the logit scale.
+#' @param obs_prob List of observation types. Each element is a vector giving
+#'   the probability of a positive observation for that type in each true state.
+#' @param start_prob Vector of starting state probabilities used to draw each
+#'   member's state on the first time step.
+#' @param complete_enroll If `TRUE`, return observations for every household
+#'   member. If `FALSE`, return only enrolled members in `obs`.
+#'
+#' @return A list with `obs` (the observed rows, either all members or only
+#'   enrolled members depending on `complete_enroll`) and `complete_obs` (every
+#'   member at every time step). When any covariate coefficient is non zero, a
+#'   third element `x` holds the simulated covariate matrix. Each observation
+#'   data frame has columns `t`, `part_id`, `enroll`, `state`, `hh_size`,
+#'   `hh_id`, and one `y` column per observation type.
+#'
+#' @examples
+#' # Simulate a basic SIR study with two observation types
+#' sim_sir(
+#'   n_hh = 20,
+#'   tmax = 50,
+#'   obs_prob = list(c(0.05, 0.95, 0.05), c(0.01, 0.01, 0.8))
+#' )
+#'
+#' @keywords internal
 sim_sir <- function(
   eh_prob = 0.01,
   ih_prob = 0.05,
@@ -185,6 +256,60 @@ sim_sir <- function(
 }
 
 
+#' @title Simulate SIIR household data
+#'
+#' @description Simulate longitudinal household outcome data for a pathogen with
+#'   two parallel infectious compartments, for example symptomatic and
+#'   asymptomatic infection. Members move through four states (1 = susceptible,
+#'   2 = first infectious compartment, 3 = second infectious compartment,
+#'   4 = recovered).
+#'
+#' @details On infection a susceptible member enters the first or second
+#'   infectious compartment according to `split`. The two infectious
+#'   compartments can have separate intra household infection probabilities and
+#'   recovery rates. As in [sim_sir()], each true state generates binary
+#'   observations through `obs_prob`.
+#'
+#' @param eh_prob Baseline per step probability that a susceptible member is
+#'   infected from outside the household.
+#' @param ih_prob Baseline per step intra household infection probability. May
+#'   be a single value (shared across both infectious compartments) or a length
+#'   two vector (one per infectious compartment).
+#' @param n_hh Number of households to simulate.
+#' @param hh_size Vector of possible household sizes; each household size is
+#'   drawn from this vector with replacement.
+#' @param tmax Number of time steps to simulate per household.
+#' @param gamma Length two vector of per step recovery probabilities, one for
+#'   each infectious compartment.
+#' @param split Length two vector giving the proportion of new infections that
+#'   enter each infectious compartment.
+#' @param covs_eh Numeric vector of coefficients for the extra household
+#'   covariates, on the logit scale.
+#' @param covs_ih Numeric vector of coefficients for the intra household
+#'   covariates, on the logit scale.
+#' @param obs_prob List of observation types. Each element is a vector giving
+#'   the probability of a positive observation for that type in each true state.
+#' @param start_prob Vector of starting state probabilities used to draw each
+#'   member's state on the first time step.
+#' @param complete_enroll If `TRUE`, return observations for every household
+#'   member. If `FALSE`, return only enrolled members in `obs`.
+#'
+#' @return A list with `obs` (the observed rows) and `complete_obs` (every
+#'   member at every time step). Each observation data frame has columns `t`,
+#'   `part_id`, `enroll`, `state`, `hh_size`, `hh_id`, and one `y` column per
+#'   observation type.
+#'
+#' @examples
+#' # Simulate a SIIR study splitting infections 70/30 across two compartments
+#' sim_siir(
+#'   n_hh = 20,
+#'   tmax = 50,
+#'   ih_prob = c(0.05, 0.025),
+#'   gamma = c(1 / 5, 1 / 3),
+#'   split = c(0.7, 0.3)
+#' )
+#'
+#' @keywords internal
 sim_siir <- function(
   eh_prob = 0.01,
   ih_prob = 0.05,
@@ -340,6 +465,56 @@ sim_siir <- function(
   list(obs = obs, complete_obs = complete_obs)
 }
 
+#' @title Simulate SEIR household data
+#'
+#' @description Simulate longitudinal household outcome data for a pathogen that
+#'   follows a susceptible-exposed-infected-recovered (SEIR) process. Members
+#'   move through four states (1 = susceptible, 2 = exposed, 3 = infected,
+#'   4 = recovered).
+#'
+#' @details Susceptible members can be infected from outside or inside the
+#'   household and first enter the exposed state. Exposed members become
+#'   infected at rate `sigma`, infected members recover at rate `gamma`, and
+#'   only infected members drive intra household transmission. As in
+#'   [sim_sir()], each true state generates binary observations through
+#'   `obs_prob`.
+#'
+#' @param eh_prob Baseline per step probability that a susceptible member is
+#'   infected from outside the household.
+#' @param ih_prob Baseline per step probability that a susceptible member is
+#'   infected by a single infected household member.
+#' @param n_hh Number of households to simulate.
+#' @param hh_size Vector of possible household sizes; each household size is
+#'   drawn from this vector with replacement.
+#' @param tmax Number of time steps to simulate per household.
+#' @param sigma Per step probability that an exposed member becomes infected.
+#' @param gamma Per step probability that an infected member recovers.
+#' @param covs_eh Numeric vector of coefficients for the extra household
+#'   covariates, on the logit scale.
+#' @param covs_ih Numeric vector of coefficients for the intra household
+#'   covariates, on the logit scale.
+#' @param obs_prob List of observation types. Each element is a vector giving
+#'   the probability of a positive observation for that type in each true state.
+#' @param start_prob Vector of starting state probabilities used to draw each
+#'   member's state on the first time step.
+#' @param complete_enroll If `TRUE`, return observations for every household
+#'   member. If `FALSE`, return only enrolled members in `obs`.
+#'
+#' @return A list with `obs` (the observed rows) and `complete_obs` (every
+#'   member at every time step). Each observation data frame has columns `t`,
+#'   `part_id`, `enroll`, `state`, `hh_size`, `hh_id`, and one `y` column per
+#'   observation type.
+#'
+#' @examples
+#' # Simulate a SEIR study with an exposed period before infectiousness
+#' sim_seir(
+#'   n_hh = 20,
+#'   tmax = 50,
+#'   sigma = 1 / 2,
+#'   gamma = 1 / 5
+#' )
+#'
+#' @keywords internal
 sim_seir <- function(
   eh_prob = 0.01,
   ih_prob = 0.05,


### PR DESCRIPTION
Adds complete roxygen documentation to the auxiliary simulation helpers in `inst/auxillary/simulation.R`: `sim_sir`, `sim_siir`, `sim_seir`, and the `make_new_obs` helper.

Each function gets a `@title`, `@description`, a `@param` entry for every argument, and a `@return` describing the output list and its columns. The three `sim_*` entry points also get short runnable `@examples`, and the SIR/SEIR/SIIR specifics are spelled out in `@details`. The style follows `R/hestia_functions.R` (markdown roxygen).

These functions live in `inst/` and are not exported, so roxygen does not generate `man/` pages for them and `NAMESPACE` is unchanged. The package could not be loaded in my local environment (missing imports, heavy Stan build), so `devtools::document()` / `roxygen2::roxygenise()` was not run to completion here; it has nothing to regenerate for these `inst/` files and CI handles any package-level regeneration.

Closes #15