### PR TITLE
Bump codecov-action v5 -> v7 (fix coverage CI: keybase key 404)

### DIFF
--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -81,7 +81,7 @@ jobs:
           name: coverage-data
 
       - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v7
         with:
           fail_ci_if_error: ${{ github.event_name != 'pull_request' || ! github.event.pull_request.head.repo.fork }}
           files: ./cobertura.xml


### PR DESCRIPTION
Coverage CI is currently failing on every non-fork PR with:

\`\`\`
gpg: no valid OpenPGP data found.
gpg: Can't check signature: No public key
==> Could not verify signature.
\`\`\`

## Root cause (verified)
\`codecov-action@v5\` verifies the downloaded codecov CLI against Codecov's PGP key fetched from \`keybase.io/codecovsecurity/pgp_keys.asc\`. Per the [v7.0.0 release notes](https://github.com/codecov/codecov-action/releases/tag/v7.0.0), Codecov **deleted the \`codecovsecurity\` keybase account** during a migration and moved the key to \`codecovsecops\`. That old URL now returns HTTP 404, so the key import yields no data and signature verification fails. With \`fail_ci_if_error\` true for non-fork PRs, the whole coverage job goes red. Confirmed independently: the old URL 404s, the new \`keybase.io/codecovsecops/pgp_keys.asc\` returns a valid key, and \`v5/dist/codecov.sh\` fetches the dead account while \`v7/dist/codecov.sh\` fetches the live one.

## Fix
Bump to \`codecov-action@v7\`, which fetches the key from \`codecovsecops\`. All five inputs this workflow uses (\`token\`, \`files\`, \`fail_ci_if_error\`, \`plugins\`, \`disable_search\`) exist unchanged in v7. This keeps signature verification on (rather than skipping it).

Unblocks the coverage check on all open PRs (e.g. #44).