### PR TITLE
CRAN submission prep: v0.1.0 + NEWS + cran-comments

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -15,3 +15,4 @@ src/*.dll
 ^LICENSE\.md$
 ^_pkgdown\.yml$
 ^pkgdown$
+^cran-comments\.md$

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: hestia
 Title: Bayesian Compartmental Infection Models from Individual Outcomes
-Version: 0.0.0.9000
+Version: 0.1.0
 Authors@R:
     c(person("Claire Perrin", "Smith", email = "clairesmith6995@gmail.com",
              role = c("aut", "cre"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,0 +1,20 @@
+# hestia 0.1.0
+
+* First release.
+* Fit Bayesian compartmental infection models from individual-level outcome
+  data, using Stan via 'rstan'. Models are composed from an infection process
+  and an observation process and fit with a single call.
+* Infection-process building blocks: `transmit()` and `progress()` define
+  transitions, assembled with `make_infection_model()`. Susceptible-infected-
+  recovered (SIR), split symptomatic/asymptomatic (SIIR), and similar
+  multi-compartment structures are supported.
+* `make_observation_model()` defines the observation process (per-compartment
+  detection probabilities for one or more tests).
+* `run_model()` fits the assembled model to the data and returns posterior
+  draws on the natural (model) scale.
+* `get_transmission_details()` exposes the parameter structure of an infection
+  model.
+* Bundled simulated datasets and fitted-draw fixtures for examples and the
+  vignettes: `sir`, `sir_cov`, `siir`, and the `sir_res`, `sir_cov_res`,
+  `siir_res` posterior draws.
+* Vignettes: "SIR" and "multiple infection compartments".

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -1,0 +1,27 @@
+## R CMD check results
+
+0 errors | 0 warnings | 1 note
+
+* This is a new submission.
+
+* checking installed package size ... NOTE
+    installed size is ~92Mb
+    sub-directories of 1Mb or more: libs
+  The package compiles its Stan models at install time via 'rstan'. The large
+  `libs` directory is the compiled model objects and is expected for packages
+  that link to Stan / StanHeaders.
+
+## Test environments
+
+* GitHub Actions (R-CMD-check workflow), R CMD check with `--as-cran`:
+  * ubuntu-latest: R-devel, R-release, R-oldrel
+  * macos-latest: R-devel, R-release, R-oldrel
+  * windows-latest: R-devel, R-release, R-oldrel
+
+<!-- TODO before submission: also run win-builder (devtools::check_win_devel()
+     / check_win_release()) and R-hub (rhub::rhub_check()), and record results
+     here. -->
+
+## Downstream dependencies
+
+There are no downstream dependencies (new package).


### PR DESCRIPTION
Prepares the submission artifacts. **Does not submit** - no release is cut, so the `cran-submission.yaml` workflow stays dormant.

## Included
- **`DESCRIPTION`**: Version `0.0.0.9000` -> `0.1.0` (release version; finishes the remaining part of #10).
- **`NEWS.md`**: first-release notes, with the `# hestia 0.1.0` heading the submission workflow checks for.
- **`cran-comments.md`**: new submission; documents the one expected NOTE - installed size ~92Mb, the compiled Stan models in `libs` (standard for rstan-linked packages). Added to `.Rbuildignore` so it is not shipped.

Check basis: the latest `--as-cran` matrix run on `main` reports **0 errors, 0 warnings, 1 NOTE** (the installed-size note above); `checking R code ... OK`.

## Still needed before an actual submission (NOT in this PR)
- **`*_res.rda` re-bake** (tracked in #48) - because #19 (done, merged in #44) moved `run_model()` output to the natural scale, the bundled fixtures must be regenerated. Heavy dedicated job.
- **win-builder + R-hub** runs (tracked in #51), recorded in `cran-comments.md`.

Then: cut the release to fire `cran-submission.yaml`; CRAN emails the maintainer (`cre`, Claire Perrin Smith) a confirmation link.

Closes #10.
Closes #49.
Closes #50.

