### PR TITLE
Port data-raw/*_res.R to the stan_options() API (#59)

### DIFF
--- a/data-raw/siir_res.R
+++ b/data-raw/siir_res.R
@@ -29,8 +29,7 @@ siir_res <- run_model(
   obs_model = obs_process,
   data = siir,
   init_probs = c(1 - 3 * 1e-10, 1e-10, 1e-10, 1e-10),
-  iter = 1000,
-  cores = 4
+  stan_opts = stan_options(iter = 1000, cores = 4)
 )
 
 usethis::use_data(siir_res, overwrite = TRUE)

--- a/data-raw/sir_cov_res.R
+++ b/data-raw/sir_cov_res.R
@@ -22,8 +22,7 @@ sir_cov_res <- run_model(
   ih_cov = sir_cov$covariates,
   eh_cov = sir_cov$covariates,
   init_probs = c(1 - 2 * 1e-10, 1e-10, 1e-10),
-  iter = 1000,
-  cores = 4
+  stan_opts = stan_options(iter = 1000, cores = 4)
 )
 
 usethis::use_data(sir_cov_res, overwrite = TRUE)

--- a/data-raw/sir_res.R
+++ b/data-raw/sir_res.R
@@ -20,8 +20,7 @@ sir_res <- run_model(
   obs_model = obs_process,
   data = sir,
   init_probs = c(1 - 2 * 1e-10, 1e-10, 1e-10),
-  iter = 1000,
-  cores = 4
+  stan_opts = stan_options(iter = 1000, cores = 4)
 )
 
 usethis::use_data(sir_res, overwrite = TRUE)


### PR DESCRIPTION
Closes #59.

#57 moved `iter`/`chains`/`cores` out of `run_model()` and into `stan_options()`. The three data-raw fixture scripts kept the old call:

```r
run_model(..., iter = 1000, cores = 4)   # errors: unused arguments
```

and now pass them through `stan_opts`:

```r
run_model(..., stan_opts = stan_options(iter = 1000, cores = 4))
```

`data-raw/` is `.Rbuildignore`'d and not run by CI or `R CMD check`, so nothing was failing — this is the latent break #59 documents. It only bites when the scripts are run to regenerate the bundled data, which makes it the prerequisite for the #48 re-bake.

Mechanical only: same `iter`/`cores` values, no behavior change to the produced fixtures. The regression guard that would have caught this class of break is tracked separately in #60.
