### PR TITLE
Make CRAN submission manual-only, decoupled from pre-releases

### DIFF
--- a/.github/workflows/cran-submission.yaml
+++ b/.github/workflows/cran-submission.yaml
@@ -1,12 +1,13 @@
 name: CRAN submission
 
+# CRAN submission is intentionally manual-only. GitHub (pre-)releases are used
+# to mint Zenodo DOIs and must NOT auto-submit to CRAN (see #68). Trigger this
+# workflow deliberately via the Actions tab / `gh workflow run`.
 on:
-  release:
-    types: [prereleased]
   workflow_dispatch:
     inputs:
       confirmation:
-        description: 'Type "CONFIRM" to submit manually (skip via release: prereleased otherwise)'
+        description: 'Type "CONFIRM" to submit to CRAN'
         required: true
         default: ''
 


### PR DESCRIPTION
## What

Removes the `release: types: [prereleased]` trigger from `.github/workflows/cran-submission.yaml`. CRAN submission is now **manual-only** via the `CONFIRM`-gated `workflow_dispatch`.

## Why

We use GitHub (pre-)releases to mint **Zenodo DOIs** (Zenodo tracking is already enabled for this repo; the DOI mints on the first published release). As wired, a pre-release also fired a real CRAN submission — so the first time anyone ticked "Set as a pre-release" it would push to CRAN. This decouples the two:

| Publish | Zenodo DOI | CRAN submission |
|---|---|---|
| Full release | ✅ | ❌ |
| Pre-release | ✅ | ❌ (was ⚠️ yes) |

CRAN submission stays available as a deliberate manual run:

```
gh workflow run cran-submission.yaml -f confirmation=CONFIRM
```

Closes #68

🤖 Generated with [Claude Code](https://claude.com/claude-code)