### PR TITLE
Point DOI badge at minted Zenodo concept DOI

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,16 +4,7 @@
 [![lint](https://github.com/ACCIDDA/hestia/actions/workflows/lint.yaml/badge.svg)](https://github.com/ACCIDDA/hestia/actions/workflows/lint.yaml)
 [![pkgdown](https://github.com/ACCIDDA/hestia/actions/workflows/pkgdown.yaml/badge.svg)](https://github.com/ACCIDDA/hestia/actions/workflows/pkgdown.yaml)
 [![codecov](https://codecov.io/gh/ACCIDDA/hestia/branch/main/graph/badge.svg)](https://app.codecov.io/gh/ACCIDDA/hestia)
-[![DOI](https://zenodo.org/badge/DOI/PENDING.svg)](https://doi.org/PENDING)
-
-<!--
-Zenodo DOI badge placeholder. Zenodo tracking is already enabled for this
-repo, but the DOI is only minted when the first GitHub Release is published.
-After that first release, replace the two PENDING values above with the
-concept DOI (the version-independent DOI that always resolves to the latest
-release). Zenodo also displays the exact badge Markdown on the deposition
-page once a release exists.
--->
+[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.20837539.svg)](https://doi.org/10.5281/zenodo.20837539)
 
 
 `{hestia}` fits Bayesian compartmental infection models — such as


### PR DESCRIPTION
## What

Replaces the two `PENDING` placeholders in the README DOI badge with the minted Zenodo **concept DOI** `10.5281/zenodo.20837539`, and removes the now-obsolete placeholder comment.

## Why

The `v0.1.0` pre-release minted the Zenodo record (concept DOI `10.5281/zenodo.20837539`, version DOI `10.5281/zenodo.20837540`). Until now the badge pointed at placeholders:

- `https://zenodo.org/badge/DOI/PENDING.svg` rendered a badge literally reading "DOI | PENDING"
- `https://doi.org/PENDING` returned **HTTP 400** — a dead click-through

The badge now uses the version-independent concept DOI, which always resolves to the latest release.

## Note

`CITATION.cff` still has no `doi:` field — a natural follow-up, left out of this PR to keep it scoped to the badge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)